### PR TITLE
Add HSTS headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,9 @@ command = "./stackbit-build.sh"
   from = "/kontakt"
   to = "/contact"
   status = 301
+
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+  Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"


### PR DESCRIPTION
Configure strict transport security headers (HSTS)
- set validity two 2 years
- include subdomains
- enable preload