### PR TITLE
Avoid contacting Google Fonts directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /public/
 /resources/_gen/
 /.hugo_build.lock
+
+# Local Netlify folder
+.netlify

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="google" content="notranslate" />
-        <link href="https://fonts.googleapis.com/css?family=Muli:400,400i,700,700i" rel="stylesheet">
+        <link href="/fonts/css?family=Muli:400,400i,700,700i" rel="stylesheet">
         <link rel="stylesheet" href="{{ (resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "assets/css/main.css" . | resources.ToCSS (dict "indentWidth" 4 "outputStyle" "nested" "precision" 10)).Permalink }}">
         {{ block "head" . }}{{ end }}
     </head>

--- a/netlify.toml
+++ b/netlify.toml
@@ -20,3 +20,13 @@ command = "hugo"
 
   [headers.values]
   Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+
+[[redirects]]
+  from = "/fonts/file/*"
+  to = "https://fonts.gstatic.com/:splat"
+  status = 200
+  force = true
+
+[[edge_functions]]
+  path = "/fonts/css"
+  function = "fonts"

--- a/netlify/edge-functions/fonts.ts
+++ b/netlify/edge-functions/fonts.ts
@@ -1,0 +1,64 @@
+import type { Context } from "https://edge.netlify.com";
+import * as css from "https://esm.sh/css@3.0.0";
+import * as contentType from "https://deno.land/x/content_type@1.0.1/mod.ts";
+
+export default async (
+  request: Request,
+  _context: Context
+): Promise<Response> => {
+  const { searchParams } = new URL(request.url);
+  const url = `https://fonts.googleapis.com/css?${searchParams.toString()}`;
+  console.log("going to:", url);
+  const resp = await fetch(url, {
+    headers: {
+      // User-Agent is used to serve the right font format
+      "User-Agent": request.headers.get("User-Agent") || "",
+    },
+  });
+  if (!resp.ok) {
+    return new Response("Request to upstream failed", { status: 503 });
+  }
+  const ct = contentType.parse(resp.headers.get("Content-Type") ?? "");
+  if (ct.type != "text/css") {
+    console.log("Response was not CSS, but was:", ct);
+    return resp;
+  }
+
+  try {
+    const newCSS = rewriteURLs(await resp.text());
+    return new Response(newCSS, resp);
+  } catch (e) {
+    return new Response(e, { status: 500 });
+  }
+};
+
+const urlRegexp = /url\(([^\)]+)\)/;
+const rewriteURLs = (text: string): string => {
+  const sheet = css.parse(text);
+  if (sheet.stylesheet?.parsingErrors?.length) {
+    throw new Error(`Invalid CSS: ${sheet.stylesheet?.parsingErrors}`);
+  }
+
+  for (const rule of sheet.stylesheet?.rules || []) {
+    if (rule.type !== "font-face") {
+      continue;
+    }
+    for (const prop of (rule as css.FontFace).declarations || []) {
+      const decl = prop as css.Declaration;
+      if (decl.property !== "src" || !decl.value) {
+        continue;
+      }
+      const matches = urlRegexp.exec(decl.value);
+      if (!matches || matches.length < 2) {
+        continue;
+      }
+      const url = new URL(matches[1]);
+      decl.value = decl.value.replace(
+        urlRegexp,
+        `url(/fonts/file${url.pathname})`
+      );
+    }
+  }
+
+  return css.stringify(sheet);
+};

--- a/netlify/edge-functions/fonts.ts
+++ b/netlify/edge-functions/fonts.ts
@@ -8,7 +8,6 @@ export default async (
 ): Promise<Response> => {
   const { searchParams } = new URL(request.url);
   const url = `https://fonts.googleapis.com/css?${searchParams.toString()}`;
-  console.log("going to:", url);
   const resp = await fetch(url, {
     headers: {
       // User-Agent is used to serve the right font format
@@ -20,8 +19,9 @@ export default async (
   }
   const ct = contentType.parse(resp.headers.get("Content-Type") ?? "");
   if (ct.type != "text/css") {
-    console.log("Response was not CSS, but was:", ct);
-    return resp;
+    return new Response(`Response was not CSS, but was: ${ct}`, {
+      status: 503,
+    });
   }
 
   try {

--- a/netlify/edge-functions/fonts.ts
+++ b/netlify/edge-functions/fonts.ts
@@ -26,7 +26,12 @@ export default async (
 
   try {
     const newCSS = rewriteURLs(await resp.text());
-    return new Response(newCSS, resp);
+    const headers = new Headers({
+      "Content-Type": "text/css; charset=utf-8",
+      "Cache-Control": resp.headers.get("cache-control") ?? "",
+      Expires: resp.headers.get("expires") ?? "",
+    });
+    return new Response(newCSS, { headers });
   } catch (e) {
     return new Response(e, { status: 500 });
   }


### PR DESCRIPTION
Since we don't want to be legal-bombed for using Google Fonts we can proxy the fonts through our site, so there is no concern about revealing the client IP of our visitors to Google directly.

The JS code in the edge function is taking the CSS from Google (varies based on User Agent) and rewrites the asset urls to be local. Doing this at build time is tricky since you need to serve different css for different browsers.