### PR TITLE
Remove Twitter social link

### DIFF
--- a/data/social.json
+++ b/data/social.json
@@ -7,12 +7,6 @@
       "url": "https://freifunk-fediverse.de/@ffddorf"
     },
     {
-      "type": "twitter",
-      "title": "Twitter",
-      "icon": "fa-twitter",
-      "url": "https://twitter.com/ffddorf"
-    },
-    {
       "title": "Facebook",
       "icon": "fa-facebook",
       "url": "https://facebook.com/freifunkddorf"


### PR DESCRIPTION
We have not been active on Twitter for years and we will most likely be never again.