### PR TITLE
🔧 Change Mastodon URL

### DIFF
--- a/data/social.json
+++ b/data/social.json
@@ -4,7 +4,7 @@
       "type": "mastodon",
       "title": "Mastodon",
       "icon": "fa-mastodon",
-      "url": "https://freifunk-fediverse.de/@ffddorf"
+      "url": "https://freifunk.social/@ffddorf"
     },
     {
       "title": "Facebook",


### PR DESCRIPTION
Link new Mastodon account on freifunk.social