### PR TITLE
Satzungsänderung: Fördermitgliedschaften

### DIFF
--- a/content/satzung.md
+++ b/content/satzung.md
@@ -50,7 +50,11 @@ Es darf keine Person durch Ausgaben, die dem Zweck der Körperschaft fremd sind,
 
 # § 7 Erwerb der Mitgliedschaft
 
-Vereinsmitglieder können natürliche Personen werden. Der Aufnahmeantrag ist schriftlich oder elektronisch zu stellen. Über den Aufnahmeantrag entscheidet der Vorstand. Weitere Voraussetzung ist, dass der Mitgliedsbeitrag entrichtet ist.
+Ordentliche Mitglieder können natürliche Personen werden.
+
+Fördermitglieder können natürliche oder juristische Personen werden. Fördermitglieder besitzen kein Stimmrecht.
+
+Der Aufnahmeantrag ist schriftlich oder elektronisch zu stellen. Über den Aufnahmeantrag entscheidet der Vorstand. Weitere Voraussetzung ist, dass der Mitgliedsbeitrag entrichtet ist.
 
 Gegen die Ablehnung, die keiner Begründung bedarf, steht dem Bewerber/der Bewerberin die Berufung einer Mitgliederversammlung zu, welche dann endgültig entscheidet.
 

--- a/content/satzung.md
+++ b/content/satzung.md
@@ -50,9 +50,10 @@ Es darf keine Person durch Ausgaben, die dem Zweck der Körperschaft fremd sind,
 
 # § 7 Erwerb der Mitgliedschaft
 
-Ordentliche Mitglieder können natürliche Personen werden.
+Es gibt folgende Arten der Vereinsmitgliedschaft:
 
-Fördermitglieder können natürliche oder juristische Personen werden. Fördermitglieder besitzen kein Stimmrecht.
+1. Ordentliche Mitglieder können natürliche Personen werden.
+1. Fördermitglieder können natürliche oder juristische Personen werden. Fördermitglieder besitzen kein Stimmrecht.
 
 Der Aufnahmeantrag ist schriftlich oder elektronisch zu stellen. Über den Aufnahmeantrag entscheidet der Vorstand. Weitere Voraussetzung ist, dass der Mitgliedsbeitrag entrichtet ist.
 


### PR DESCRIPTION
Die regelmäßige Akquise von Spendengeldern bedeutet einen wiederholenden Arbeitsaufwand. Laufende Kosten machen stetige Einnahmen aus Spenden notwendig. Um den Arbeitsaufwand zu minimieren, bietet sich die Einführung von Fördermitgliedschaften an. Diese möchten wir unseren Kooperationspartnern anbieten, um eine einfache und vertraglich zugesicherte regelmäßige Einnahme zu erzielen. Fördermitgliedschaften geben uns eine bessere Planbarkeit, auch im Falle ordentlicher Kündigungen.